### PR TITLE
feat: User Entity 구조 변경

### DIFF
--- a/withins_server/core/src/main/java/com/withins/core/BaseEntity.java
+++ b/withins_server/core/src/main/java/com/withins/core/BaseEntity.java
@@ -4,15 +4,19 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+@SuperBuilder
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor
 public abstract class BaseEntity {
     @Column(updatable = false)
     @CreatedDate

--- a/withins_server/core/src/main/java/com/withins/core/user/component/UserReader.java
+++ b/withins_server/core/src/main/java/com/withins/core/user/component/UserReader.java
@@ -1,6 +1,7 @@
 package com.withins.core.user.component;
 
 import com.withins.core.exception.EntityNotFoundException;
+import com.withins.core.user.entity.Provider;
 import com.withins.core.user.entity.Role;
 import com.withins.core.user.entity.User;
 import com.withins.core.user.repository.UserRepository;
@@ -18,7 +19,7 @@ public class UserReader {
     private final UserRepository userRepository;
 
     public Optional<User> readBy(final String socialUserId) {
-        return userRepository.findBySocialUserId(socialUserId);
+        return userRepository.findBySocialUser(Provider.KAKAO, socialUserId);
     }
 
     public Role readRole(final Long userId) {

--- a/withins_server/core/src/main/java/com/withins/core/user/component/UserWriter.java
+++ b/withins_server/core/src/main/java/com/withins/core/user/component/UserWriter.java
@@ -1,7 +1,8 @@
 package com.withins.core.user.component;
 
+import com.withins.core.user.entity.Provider;
 import com.withins.core.user.entity.Role;
-import com.withins.core.user.entity.User;
+import com.withins.core.user.entity.SocialUser;
 import com.withins.core.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,11 +17,12 @@ public class UserWriter {
 
     public Long save(final String socialUserId, final String nickname) {
         return userRepository.save(
-                User.builder()
-                        .socialUserId(socialUserId)
-                        .nickname(nickname)
-                        .role(Role.USER)
-                        .build()
+                SocialUser.builder()
+                    .provider(Provider.KAKAO)
+                    .providerId(socialUserId)
+                    .nickname(nickname)
+                    .role(Role.USER)
+                    .build()
         ).getId();
     }
 }

--- a/withins_server/core/src/main/java/com/withins/core/user/entity/OrgUser.java
+++ b/withins_server/core/src/main/java/com/withins/core/user/entity/OrgUser.java
@@ -1,0 +1,23 @@
+package com.withins.core.user.entity;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+
+@Entity
+@DiscriminatorValue("org")
+@SuperBuilder
+@Getter
+@NoArgsConstructor
+public final class OrgUser extends User {
+
+
+    @Override
+    protected String getDiscriminatorValue() {
+        return "org";
+    }
+
+
+}

--- a/withins_server/core/src/main/java/com/withins/core/user/entity/Provider.java
+++ b/withins_server/core/src/main/java/com/withins/core/user/entity/Provider.java
@@ -1,0 +1,7 @@
+package com.withins.core.user.entity;
+
+public enum Provider {
+
+    KAKAO;
+
+}

--- a/withins_server/core/src/main/java/com/withins/core/user/entity/SocialUser.java
+++ b/withins_server/core/src/main/java/com/withins/core/user/entity/SocialUser.java
@@ -1,0 +1,26 @@
+package com.withins.core.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@DiscriminatorValue("social")
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+@Getter
+public final class SocialUser extends User {
+
+    @Enumerated(EnumType.STRING)
+    private Provider provider;
+    private String providerId;
+
+    @Override
+    protected String getDiscriminatorValue() {
+        return "social";
+    }
+}

--- a/withins_server/core/src/main/java/com/withins/core/user/entity/User.java
+++ b/withins_server/core/src/main/java/com/withins/core/user/entity/User.java
@@ -3,21 +3,21 @@ package com.withins.core.user.entity;
 import com.withins.core.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Table(name = "users")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "type")
 @Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Builder
-public class User extends BaseEntity {
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@SuperBuilder
+public abstract class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    @Column(nullable = false, unique = true)
-    private String socialUserId;
 
     @Column(nullable = false)
     private String nickname;
@@ -25,4 +25,12 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Role role;
+
+    @Column(name = "type", insertable = false, updatable = false)
+    private String type = getDiscriminatorValue();
+
+    /*
+     상속 전략의 구분자(Discriminator)를 사용하는 'type' 컬럼과 매핑됩니다.
+     */
+    protected abstract String getDiscriminatorValue();
 }

--- a/withins_server/core/src/main/java/com/withins/core/user/repository/UserRepository.java
+++ b/withins_server/core/src/main/java/com/withins/core/user/repository/UserRepository.java
@@ -1,10 +1,15 @@
 package com.withins.core.user.repository;
 
+import com.withins.core.user.entity.Provider;
 import com.withins.core.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findBySocialUserId(String socialUserId);
+
+    @Query("SELECT u FROM SocialUser u WHERE u.provider = :provider AND u.providerId = :providerId")
+    Optional<User> findBySocialUser(@Param("provider") Provider provider, @Param("providerId") String providerId);
 }

--- a/withins_server/core/src/test/java/com/withins/core/user/service/UserServiceTest.java
+++ b/withins_server/core/src/test/java/com/withins/core/user/service/UserServiceTest.java
@@ -1,7 +1,9 @@
 package com.withins.core.user.service;
 
 import com.withins.core.config.IntegrationTest;
+import com.withins.core.user.entity.Provider;
 import com.withins.core.user.entity.Role;
+import com.withins.core.user.entity.SocialUser;
 import com.withins.core.user.entity.User;
 import com.withins.core.user.repository.UserRepository;
 import org.junit.jupiter.api.Test;
@@ -22,8 +24,9 @@ class UserServiceTest extends IntegrationTest {
     void 이미_가입된_회원은_로그인시_재가입되지_않는다() {
         //given
         userRepository.save(
-                User.builder()
-                        .socialUserId("testSocialUserId")
+                SocialUser.builder()
+                        .provider(Provider.KAKAO)
+                        .providerId("testSocialUserId")
                         .nickname("testNickname")
                         .role(Role.USER)
                         .build()


### PR DESCRIPTION
## 연관된 이슈
JWT 로그인 방식 통합전에 User 설정

## 작업 내용
- User Entity 구조변경
String socialUserId -> String providerId 로 변경
Provider provider 추가
Discriminator 적용으로 Abstract User -> Implements OrgUser, SocialUser 기관유저와 소셜유저로 구분
상속관계 Builder 패턴을 확장해서 SuperBuilder 적용

- 구조변경으로 인한 서비스 로직 변경
UserRepository findBySocialUserId(String socialUserId) -> findBySocialUser( Provider provider, String providerId) 로 Provider도 함께 검증하도록 변경


## 리뷰 요구사항
SuperBuilder 어노테이션을 사용하면서 상속관계의 모든 클래스에 SuperBuilder가 강제됨 따라서 BaseEntity에도 어쩔수없이 SuperBuilder 어노테이션이 들어감

왜 SuperBuilder를 채택했나?
1. 기존 Builder 패턴을 변경없이 그대로 사용하기 위함
2. SuperBuilder를 사용하지않으면 Builder패턴으로 상속관계에 있는 클래스에 접근이 불가능함 가능하기는 한데 커스텀빌더를 직접 만들어야하는 수고로움이 있음 -> 유지보수코드가 증가
3. SuperBuilder를 사용하면 SocialUser.builder().nickname("닉네임") 이런식으로 부모 클래스의 빌더에 접근이 가능해짐

BaseEntity에 @SuperBuilder 가 있으면 무슨 일이 일어날까
1. BaseEntity를 상속받고있는 클래스에 @SuperBuilder가 있다면 BaseEntity 멤버변수에 builder로 접근이 가능함 SocialUser.builder().createdDate(LocalDateTime.of(2000, 1, 1, 0, 0)) 이렇게 작성이 가능함 물론 JPA에서 현재시간으로 만들어서 넣어주기때문에 조작이 불가능함 - 확인해봄
2. 상속받는 클래스에 일반 @Builder를 쓸수있나? - 쓸수있음 당연하게도 이때는 BaseEntity builder로는 접근이 불가능함

BaseEntity에 SuperBuilder 가 있을때 위와 같은 일이 일어날 수 있음 그 외 다른 문제가 생길것같다면 리뷰해주세요
