### PR TITLE
feat: Lambda 응답구조 개선

### DIFF
--- a/withins_server/crawl-batch/build.gradle.kts
+++ b/withins_server/crawl-batch/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation("software.amazon.awssdk:ecs:${awsSdkEcsVersion}")
     implementation("software.amazon.awssdk:s3:${awsSdkS3Version}")
     implementation("software.amazon.awssdk:lambda:${awsSdkLambdaVersion}")
+    implementation("software.amazon.awssdk:apache-client:${awsSdkLambdaVersion}")
 
     //TODO org.json:json 라이브러리는 jackson 라이브러리로 대체 예정
     implementation("org.json:json:20230618")

--- a/withins_server/crawl-batch/src/main/java/com/withins/crawl/CrawlBatchConfig.java
+++ b/withins_server/crawl-batch/src/main/java/com/withins/crawl/CrawlBatchConfig.java
@@ -10,6 +10,7 @@ import jakarta.persistence.EntityManagerFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.core.job.builder.JobBuilder;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.batch.core.step.builder.StepBuilder;
@@ -19,12 +20,14 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
-import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.util.CollectionUtils;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -116,6 +119,13 @@ public class CrawlBatchConfig {
 
     @Bean
     public LambdaClient lambdaClient() {
-        return LambdaClient.builder().build();
+        return LambdaClient.builder()
+                .httpClientBuilder(ApacheHttpClient.builder()
+                        .socketTimeout(Duration.ofMinutes(5)))  // 소켓 타임아웃 설정
+                .overrideConfiguration(ClientOverrideConfiguration.builder()
+                        .apiCallTimeout(Duration.ofMinutes(5))  // 전체 API 호출 타임아웃
+                        .apiCallAttemptTimeout(Duration.ofMinutes(5))  // 각 시도당 타임아웃
+                        .build())
+                .build();
     }
 }

--- a/withins_server/crawl-batch/src/main/java/com/withins/crawl/LambdaExecutionResult.java
+++ b/withins_server/crawl-batch/src/main/java/com/withins/crawl/LambdaExecutionResult.java
@@ -1,34 +1,43 @@
 package com.withins.crawl;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import org.json.JSONObject;
 import software.amazon.awssdk.services.lambda.model.InvokeResponse;
 
-import java.nio.charset.StandardCharsets;
+import java.io.IOException;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class LambdaExecutionResult {
+
+    private static final ObjectMapper objectMapper;
+
+    static {
+        objectMapper = new ObjectMapper();
+    }
 
     private final int statusCode;
     private final String rawResponse;
-    private final JSONObject jsonResponse;
     private final LambdaResponseData responseData;
     private String errorMessage;
 
     public static LambdaExecutionResult from(InvokeResponse response) {
         int statusCode = response.statusCode();
         String rawResponse = response.payload().asUtf8String();
-        JSONObject jsonObject = new JSONObject(rawResponse);
-        LambdaResponseData responseData = LambdaResponseData.from(jsonObject);
 
-        return new LambdaExecutionResult(statusCode, rawResponse, jsonObject, responseData);
+        try {
+            LambdaResponseData responseData = objectMapper.readValue(rawResponse, LambdaResponseData.class);
+            return new LambdaExecutionResult(statusCode, rawResponse, responseData, null);
+        } catch (IOException e) {
+            return ofError(statusCode, e.getMessage());
+        }
     }
 
     public static LambdaExecutionResult ofError(int statusCode, String errorMessage) {
@@ -36,13 +45,12 @@ public class LambdaExecutionResult {
                 statusCode,
                 null,
                 null,
-                null,
                 errorMessage
         );
     }
 
     public boolean isSuccess() {
-        return statusCode == 200 && responseData.isSuccess();
+        return statusCode == 200 && responseData != null && responseData.isSuccess();
     }
 
     public boolean isInvocationSuccessful() {
@@ -50,63 +58,93 @@ public class LambdaExecutionResult {
     }
 
     public String getS3Location() {
-        return responseData.getS3Location();
+        return responseData != null && responseData.getData() != null ? 
+               responseData.getData().getS3Location() : null;
     }
 
     public String getJsonResponse() {
-        return jsonResponse.toString();
+        try {
+            return responseData != null ? objectMapper.writeValueAsString(responseData) : null;
+        } catch (JsonProcessingException e) {
+            return null;
+        }
     }
 
     /**
      * Lambda 응답 데이터를 표현하는 내부 클래스
      */
-    //TODO Jackson을 사용한 개선 예정
     @Getter
-    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class LambdaResponseData {
         private final boolean success;
         private final String message;
         private final String targetDate;
         private final String jobName;
-        private final String error;
+        private DataObject data; // non-final 유지
+        private ErrorObject error; // non-final 유지
         private final String timestamp;
-        private final String s3Location;
-        //TODO processedJobs를 List에서 String으로 개선 예정(크롤링 서버 수정 후)
-        private final List<String> processedJobs;
-        private final Integer itemCount;
-        private final Integer duration;
 
-        public static LambdaResponseData from(JSONObject json) {
-            boolean success = json.optBoolean("success");
-            String message = json.optString("message", null);
-            String targetDate = json.optString("targetDate", null);
-            String jobName = json.optString("jobName", null);
-            String error = json.optString("error", null);
-            String timestamp = json.optString("timestamp", null);
+        @JsonCreator
+        public LambdaResponseData(
+                @JsonProperty("success") boolean success,
+                @JsonProperty("message") String message,
+                @JsonProperty("targetDate") String targetDate,
+                @JsonProperty("jobName") String jobName,
+                @JsonProperty("data") DataObject data,
+                @JsonProperty("error") ErrorObject error,
+                @JsonProperty("timestamp") String timestamp
+        ) {
+            this.success = success;
+            this.message = message;
+            this.targetDate = targetDate;
+            this.jobName = jobName;
+            this.data = data;
+            this.error = error;
+            this.timestamp = timestamp;
+        }
 
-            String s3Location = null;
-            List<String> processedJobs = null;
-            Integer itemCount = null;
-            Integer duration = null;
+        @Getter
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        public static class DataObject {
+            private final List<String> processedJobs;
+            private final String s3Location;
+            private final Integer itemCount;
+            private final Integer duration;
 
-            // 성공한 경우 data 객체에서 추가 정보 추출
-            if (success && json.has("data")) {
-                JSONObject data = json.getJSONObject("data");
-                s3Location = data.optString("s3Location", null);
-                itemCount = data.has("itemCount") ? data.getInt("itemCount") : null;
-                duration = data.has("duration") ? data.getInt("duration") : null;
-
-                if (data.has("processedJobs")) {
-                    processedJobs = IntStream.range(0, data.getJSONArray("processedJobs").length())
-                            .mapToObj(i -> data.getJSONArray("processedJobs").getString(i))
-                            .collect(Collectors.toList());
-                }
+            @JsonCreator
+            public DataObject(
+                    @JsonProperty("processedJobs") List<String> processedJobs,
+                    @JsonProperty("s3Location") String s3Location,
+                    @JsonProperty("itemCo  unt") Integer itemCount,
+                    @JsonProperty("duration") Integer duration
+            ) {
+                this.processedJobs = processedJobs;
+                this.s3Location = s3Location;
+                this.itemCount = itemCount;
+                this.duration = duration;
             }
+        }
 
-            return new LambdaResponseData(
-                    success, message, targetDate, jobName, error, timestamp,
-                    s3Location, processedJobs, itemCount, duration
-            );
+        @Getter
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        public static class ErrorObject {
+            private final String message;
+            private final String context;
+            private final String stack;
+
+            @JsonCreator
+            public ErrorObject(
+                    @JsonProperty("message") String message,
+                    @JsonProperty("context") String context,
+                    @JsonProperty("stack") String stack
+            ) {
+                this.message = message;
+                this.context = context;
+                this.stack = stack;
+            }
         }
     }
 }


### PR DESCRIPTION
## 연관된 이슈
#54 
## 작업 내용
- AWS Lambda 응답구조에 맞춰 코드 개선
- AWS SDK 소켓 타임아웃 수정

```
### 성공 응답

{
  "success": true,
  "message": "크롤링 및 S3 업로드 성공",
  "targetDate": "2025-07-07",
  "jobName": "XXXXXX복지관",
  "data": {
    "processedJobs": [
      "XXXXXX복지관"
    ],
    "s3Location": "s3://crawl-json-bucket/crawling-results/2025-07-07/XXXXXX복지관/2025-07-10-09-35-02.json",
    "itemCount": 24,
    "duration": 8493
  },
  "timestamp": "2025-07-10T18:35:02+09:00"
}
```
### 실패 응답

```
{
  "success": false,
  "message": "크롤링 실패",
  "targetDate": "2025-07-07",
  "jobName": "XXXXXX협회",
  "error": {
    "message": "page.waitForSelector: Timeout 30000ms exceeded.\nCall log:\n  - waiting for locator('table.bd_lst.bd_tb_lst.bd_tb tbody tr')\n",
    "context": "Job 실행",
    "stack": "page.waitForSelector: Timeout 30000ms exceeded.\nCall log:\n  - waiting for locator('table.bd_lst.bd_tb_lst.bd_tb tbody tr')\n\n    at 공지사항.execute (/var/task/entity/step/SimpleTemplateStep.js:17:20)\n    at async 공지사항.run (/var/task/entity/step/AbstractStep.js:7:24)\n    at async XXXXXX.runSteps (/var/task/entity/job/AbstractJob.js:27:28)\n    at async XXXXXX.run (/var/task/entity/job/AbstractJob.js:21:20)\n    at async JobExecutor.execute (/var/task/entity/job/JobExecutor.js:17:28)\n    at async CrawlingService.executeJob (/var/task/aws/lambda/CrawlingService.js:132:28)\n    at async CrawlingService.executeCrawling (/var/task/aws/lambda/CrawlingService.js:75:41)\n    at async Runtime.crawl (/var/task/aws/lambda/handler.js:24:32)"
  },
  "timestamp": "2025-07-10T16:18:08+09:00"
}
```

### 소켓 타임아웃
```
    @Bean
    public LambdaClient lambdaClient() {
        return LambdaClient.builder()
                .httpClientBuilder(ApacheHttpClient.builder()
                        .socketTimeout(Duration.ofMinutes(5)))  // 소켓 타임아웃 설정
                .overrideConfiguration(ClientOverrideConfiguration.builder()
                        .apiCallTimeout(Duration.ofMinutes(5))  // 전체 API 호출 타임아웃
                        .apiCallAttemptTimeout(Duration.ofMinutes(5))  // 각 시도당 타임아웃
                        .build())
                .build();
    }
```
AWS Console 환경에서 AWS Lambda를 호출하면 크롤링이 실패하더라도 정상적으로 실패응답이 발생한다.
반면에 Spring Batch에서 AWS Lambda 함수를 트리거했을 때 Timeout오류가 발생한다. 이는 네트워크 타임아웃이 발생한 것으로 소켓 레벨에서 타임아웃이 발생한 것이다.

AWS Lambda에서 제한시간을 5분으로 구성하여 그에 맞춰 5분으로 지정했습니다.

## 리뷰 요구사항
